### PR TITLE
fix: guard empty buffers across xev/cxev async paths

### DIFF
--- a/pkg/cxev/buffer.go
+++ b/pkg/cxev/buffer.go
@@ -1,0 +1,16 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Mitchell Hashimoto
+ * Copyright (c) 2026 Crrow
+ */
+
+package cxev
+
+import "unsafe"
+
+func bufferPointer(buf []byte) unsafe.Pointer {
+	if len(buf) == 0 {
+		return nil
+	}
+	return unsafe.Pointer(&buf[0])
+}

--- a/pkg/cxev/empty_buffer_test.go
+++ b/pkg/cxev/empty_buffer_test.go
@@ -1,0 +1,26 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Mitchell Hashimoto
+ * Copyright (c) 2026 Crrow
+ */
+
+package cxev
+
+import "testing"
+
+func TestRegisterReadCallbacksWithEmptyBuffer(t *testing.T) {
+	tcpID := RegisterTCPReadCallback(func(loop *Loop, c *TCPCompletion, buf []byte, bytesRead int32, err int32, userdata uintptr) CbAction {
+		return Disarm
+	}, []byte{})
+	UnregisterTCPCallback(tcpID)
+
+	fileID := RegisterFileReadCallback(func(loop *Loop, c *FileCompletion, buf []byte, bytesRead int32, err int32, userdata uintptr) CbAction {
+		return Disarm
+	}, []byte{})
+	UnregisterFileCallback(fileID)
+
+	udpID := RegisterUDPReadCallback(func(loop *Loop, c *UDPCompletion, remoteAddr *Sockaddr, buf []byte, bytesRead int32, err int32, userdata uintptr) CbAction {
+		return Disarm
+	}, []byte{})
+	UnregisterUDPCallback(udpID)
+}

--- a/pkg/cxev/file.go
+++ b/pkg/cxev/file.go
@@ -225,9 +225,8 @@ func fileTrampoline(cif *ffi.Cif, ret unsafe.Pointer, args *unsafe.Pointer, user
 
 // fileReadContext holds the buffer pointer and length for read callbacks.
 type fileReadContext struct {
-	cb     FileReadCallback
-	buf    []byte
-	bufPtr uintptr
+	cb  FileReadCallback
+	buf []byte
 }
 
 func fileReadTrampoline(cif *ffi.Cif, ret unsafe.Pointer, args *unsafe.Pointer, userData unsafe.Pointer) uintptr {
@@ -298,7 +297,7 @@ func RegisterFileCallback(cb FileCallback) uintptr {
 // RegisterFileReadCallback registers a File read callback with its buffer.
 func RegisterFileReadCallback(cb FileReadCallback, buf []byte) uintptr {
 	id := uintptr(atomic.AddUint64(&fileCallbackCounter, 1))
-	fileReadCallbackRegistry.Store(id, fileReadContext{cb: cb, buf: buf, bufPtr: uintptr(unsafe.Pointer(&buf[0]))})
+	fileReadCallbackRegistry.Store(id, fileReadContext{cb: cb, buf: buf})
 	return id
 }
 
@@ -339,7 +338,7 @@ func FileRead(file *File, loop *Loop, c *FileCompletion, buf []byte, userdata, c
 	filePtr := unsafe.Pointer(file)
 	loopPtr := unsafe.Pointer(loop)
 	cPtr := unsafe.Pointer(c)
-	bufPtr := unsafe.Pointer(&buf[0])
+	bufPtr := bufferPointer(buf)
 	bufLen := uint64(len(buf))
 	fnFileRead.Call(nil, &filePtr, &loopPtr, &cPtr, &bufPtr, &bufLen, &cb, &userdata)
 }
@@ -357,7 +356,7 @@ func FileWrite(file *File, loop *Loop, c *FileCompletion, buf []byte, userdata, 
 	filePtr := unsafe.Pointer(file)
 	loopPtr := unsafe.Pointer(loop)
 	cPtr := unsafe.Pointer(c)
-	bufPtr := unsafe.Pointer(&buf[0])
+	bufPtr := bufferPointer(buf)
 	bufLen := uint64(len(buf))
 	fnFileWrite.Call(nil, &filePtr, &loopPtr, &cPtr, &bufPtr, &bufLen, &cb, &userdata)
 }
@@ -375,7 +374,7 @@ func FilePRead(file *File, loop *Loop, c *FileCompletion, buf []byte, offset uin
 	filePtr := unsafe.Pointer(file)
 	loopPtr := unsafe.Pointer(loop)
 	cPtr := unsafe.Pointer(c)
-	bufPtr := unsafe.Pointer(&buf[0])
+	bufPtr := bufferPointer(buf)
 	bufLen := uint64(len(buf))
 	fnFilePRead.Call(nil, &filePtr, &loopPtr, &cPtr, &bufPtr, &bufLen, &offset, &cb, &userdata)
 }
@@ -393,7 +392,7 @@ func FilePWrite(file *File, loop *Loop, c *FileCompletion, buf []byte, offset ui
 	filePtr := unsafe.Pointer(file)
 	loopPtr := unsafe.Pointer(loop)
 	cPtr := unsafe.Pointer(c)
-	bufPtr := unsafe.Pointer(&buf[0])
+	bufPtr := bufferPointer(buf)
 	bufLen := uint64(len(buf))
 	fnFilePWrite.Call(nil, &filePtr, &loopPtr, &cPtr, &bufPtr, &bufLen, &offset, &cb, &userdata)
 }

--- a/pkg/cxev/tcp.go
+++ b/pkg/cxev/tcp.go
@@ -429,9 +429,8 @@ func tcpAcceptTrampoline(cif *ffi.Cif, ret unsafe.Pointer, args *unsafe.Pointer,
 
 // tcpReadContext holds the buffer pointer and length for read callbacks.
 type tcpReadContext struct {
-	cb     TCPReadCallback
-	buf    []byte
-	bufPtr uintptr
+	cb  TCPReadCallback
+	buf []byte
 }
 
 func tcpReadTrampoline(cif *ffi.Cif, ret unsafe.Pointer, args *unsafe.Pointer, userData unsafe.Pointer) uintptr {
@@ -502,7 +501,7 @@ func RegisterTCPAcceptCallback(cb TCPAcceptCallback) uintptr {
 // RegisterTCPReadCallback registers a TCP read callback with its buffer.
 func RegisterTCPReadCallback(cb TCPReadCallback, buf []byte) uintptr {
 	id := uintptr(atomic.AddUint64(&tcpCallbackCounter, 1))
-	tcpReadCallbackRegistry.Store(id, tcpReadContext{cb: cb, buf: buf, bufPtr: uintptr(unsafe.Pointer(&buf[0]))})
+	tcpReadCallbackRegistry.Store(id, tcpReadContext{cb: cb, buf: buf})
 	return id
 }
 
@@ -583,7 +582,7 @@ func TCPRead(tcp *TCP, loop *Loop, c *TCPCompletion, buf []byte, userdata, cb ui
 	tcpPtr := unsafe.Pointer(tcp)
 	loopPtr := unsafe.Pointer(loop)
 	cPtr := unsafe.Pointer(c)
-	bufPtr := unsafe.Pointer(&buf[0])
+	bufPtr := bufferPointer(buf)
 	bufLen := uint64(len(buf))
 	fnTCPRead.Call(nil, &tcpPtr, &loopPtr, &cPtr, &bufPtr, &bufLen, &userdata, &cb)
 }
@@ -601,7 +600,7 @@ func TCPWrite(tcp *TCP, loop *Loop, c *TCPCompletion, buf []byte, userdata, cb u
 	tcpPtr := unsafe.Pointer(tcp)
 	loopPtr := unsafe.Pointer(loop)
 	cPtr := unsafe.Pointer(c)
-	bufPtr := unsafe.Pointer(&buf[0])
+	bufPtr := bufferPointer(buf)
 	bufLen := uint64(len(buf))
 	fnTCPWrite.Call(nil, &tcpPtr, &loopPtr, &cPtr, &bufPtr, &bufLen, &userdata, &cb)
 }

--- a/pkg/cxev/udp.go
+++ b/pkg/cxev/udp.go
@@ -379,7 +379,7 @@ func UDPRead(udp *UDP, loop *Loop, c *UDPCompletion, state *UDPState, buf []byte
 	loopPtr := unsafe.Pointer(loop)
 	cPtr := unsafe.Pointer(c)
 	statePtr := unsafe.Pointer(state)
-	bufPtr := unsafe.Pointer(&buf[0])
+	bufPtr := bufferPointer(buf)
 	bufLen := uint64(len(buf))
 	fnUDPRead.Call(nil, &udpPtr, &loopPtr, &cPtr, &statePtr, &bufPtr, &bufLen, &userdata, &cb)
 }
@@ -399,7 +399,7 @@ func UDPWrite(udp *UDP, loop *Loop, c *UDPCompletion, state *UDPState, addr *Soc
 	cPtr := unsafe.Pointer(c)
 	statePtr := unsafe.Pointer(state)
 	addrPtr := unsafe.Pointer(addr)
-	bufPtr := unsafe.Pointer(&buf[0])
+	bufPtr := bufferPointer(buf)
 	bufLen := uint64(len(buf))
 	fnUDPWrite.Call(nil, &udpPtr, &loopPtr, &cPtr, &statePtr, &addrPtr, &bufPtr, &bufLen, &userdata, &cb)
 }

--- a/pkg/xev/empty_buffer_test.go
+++ b/pkg/xev/empty_buffer_test.go
@@ -1,0 +1,105 @@
+/*
+ * MIT License
+ * Copyright (c) 2023 Mitchell Hashimoto
+ * Copyright (c) 2026 Crrow
+ */
+
+package xev
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/crrow/libxev-go/pkg/cxev"
+)
+
+func TestEmptyBufferReturnsError(t *testing.T) {
+	if !cxev.ExtLibLoaded() {
+		t.Skip("extended library not loaded")
+	}
+
+	loop, err := NewLoop()
+	if err != nil {
+		t.Fatalf("NewLoop failed: %v", err)
+	}
+	defer loop.Close()
+
+	udpConn, err := NewUDPConn()
+	if err != nil {
+		t.Fatalf("NewUDPConn failed: %v", err)
+	}
+	defer udpConn.Cleanup()
+
+	tcpConn, err := Dial("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+
+	udpAddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}
+
+	checkEmptyErr := func(name string, err error) {
+		t.Helper()
+		if !errors.Is(err, ErrEmptyBuffer) {
+			t.Fatalf("%s: expected ErrEmptyBuffer, got %v", name, err)
+		}
+	}
+
+	checkEmptyErr("tcp read", tcpConn.ReadFunc(loop, []byte{}, func(conn *TCPConn, data []byte, err error) Action {
+		return Stop
+	}))
+	checkEmptyErr("tcp write", tcpConn.WriteFunc(loop, []byte{}, func(conn *TCPConn, bytesWritten int, err error) Action {
+		return Stop
+	}))
+
+	checkEmptyErr("udp read", udpConn.ReadFromFunc(loop, []byte{}, func(conn *UDPConn, data []byte, remoteAddr *net.UDPAddr, err error) Action {
+		return Stop
+	}))
+	checkEmptyErr("udp write to", udpConn.WriteToFunc(loop, []byte{}, "127.0.0.1:12345", func(conn *UDPConn, bytesWritten int, err error) Action {
+		return Stop
+	}))
+	checkEmptyErr("udp write to addr", udpConn.WriteToAddrFunc(loop, []byte{}, udpAddr, func(conn *UDPConn, bytesWritten int, err error) Action {
+		return Stop
+	}))
+}
+
+func TestFileEmptyBufferReturnsError(t *testing.T) {
+	if !cxev.ExtLibLoaded() {
+		t.Skip("extended library not loaded")
+	}
+
+	loop, err := NewLoopWithThreadPool()
+	if err != nil {
+		t.Fatalf("NewLoopWithThreadPool failed: %v", err)
+	}
+	defer loop.Close()
+
+	path := filepath.Join(t.TempDir(), "empty-buffer.txt")
+	file, err := OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		t.Fatalf("OpenFile failed: %v", err)
+	}
+	defer file.Cleanup()
+
+	checkEmptyErr := func(name string, err error) {
+		t.Helper()
+		if !errors.Is(err, ErrEmptyBuffer) {
+			t.Fatalf("%s: expected ErrEmptyBuffer, got %v", name, err)
+		}
+	}
+
+	checkEmptyErr("file read", file.ReadFunc(loop, []byte{}, func(file *File, data []byte, err error) Action {
+		return Stop
+	}))
+	checkEmptyErr("file write", file.WriteFunc(loop, []byte{}, func(file *File, bytesWritten int, err error) Action {
+		return Stop
+	}))
+	checkEmptyErr("file pread", file.PReadFunc(loop, []byte{}, 0, func(file *File, data []byte, err error) Action {
+		return Stop
+	}))
+	checkEmptyErr("file pwrite", file.PWriteFunc(loop, []byte{}, 0, func(file *File, bytesWritten int, err error) Action {
+		return Stop
+	}))
+}

--- a/pkg/xev/file.go
+++ b/pkg/xev/file.go
@@ -234,6 +234,10 @@ func (f *File) Fd() int32 {
 // Return [Continue] from the handler to keep reading sequentially, or [Stop]
 // to stop.
 func (f *File) Read(loop *Loop, buf []byte, handler FileReadHandler) error {
+	if len(buf) == 0 {
+		return ErrEmptyBuffer
+	}
+
 	op := &fileOp{
 		file:        f,
 		loop:        loop,
@@ -277,6 +281,10 @@ func (op *fileOp) readCallback(loop *cxev.Loop, c *cxev.FileCompletion, data []b
 //
 // The handler's OnWrite method is called when the write completes.
 func (f *File) Write(loop *Loop, data []byte, handler FileWriteHandler) error {
+	if len(data) == 0 {
+		return ErrEmptyBuffer
+	}
+
 	op := &fileOp{
 		file:         f,
 		loop:         loop,
@@ -324,6 +332,10 @@ func (op *fileOp) writeCallback(loop *cxev.Loop, c *cxev.FileCompletion, bytesWr
 //
 // The offset is in bytes from the start of the file.
 func (f *File) PRead(loop *Loop, buf []byte, offset uint64, handler FileReadHandler) error {
+	if len(buf) == 0 {
+		return ErrEmptyBuffer
+	}
+
 	op := &fileOp{
 		file:        f,
 		loop:        loop,
@@ -354,6 +366,10 @@ func (f *File) PReadFunc(loop *Loop, buf []byte, offset uint64, fn func(file *Fi
 //
 // The offset is in bytes from the start of the file.
 func (f *File) PWrite(loop *Loop, data []byte, offset uint64, handler FileWriteHandler) error {
+	if len(data) == 0 {
+		return ErrEmptyBuffer
+	}
+
 	op := &fileOp{
 		file:         f,
 		loop:         loop,

--- a/pkg/xev/tcp.go
+++ b/pkg/xev/tcp.go
@@ -18,6 +18,9 @@ import (
 // variable to the path of libxev_extended.dylib/.so/.dll.
 var ErrExtLibNotLoaded = errors.New("extended library (TCP support) not loaded; set LIBXEV_EXT_PATH")
 
+// ErrEmptyBuffer is returned when an async read/write API is called with an empty buffer.
+var ErrEmptyBuffer = errors.New("buffer cannot be empty")
+
 // TCPListener accepts incoming TCP connections.
 //
 // Create a listener with [Listen], then call [TCPListener.Accept] or
@@ -350,6 +353,10 @@ func (c *TCPConn) Connect(loop *Loop, address string, handler func(conn *TCPConn
 // The provided buffer is used for the read operation. The data slice passed
 // to the handler is a slice of this buffer containing the bytes read.
 func (c *TCPConn) Read(loop *Loop, buf []byte, handler ReadHandler) error {
+	if len(buf) == 0 {
+		return ErrEmptyBuffer
+	}
+
 	c.loop = loop
 	c.readHandler = handler
 	c.readBuf = buf
@@ -383,6 +390,10 @@ func (c *TCPConn) readCallback(loop *cxev.Loop, comp *cxev.TCPCompletion, data [
 // The handler's OnWrite method is called when the write completes. The
 // bytesWritten parameter indicates how many bytes were successfully written.
 func (c *TCPConn) Write(loop *Loop, data []byte, handler WriteHandler) error {
+	if len(data) == 0 {
+		return ErrEmptyBuffer
+	}
+
 	c.loop = loop
 	c.writeHandler = handler
 

--- a/pkg/xev/udp.go
+++ b/pkg/xev/udp.go
@@ -229,6 +229,10 @@ func (c *UDPConn) LocalAddr() (string, uint16) {
 //
 // Return [Continue] from the handler to keep receiving, or [Stop] to stop.
 func (c *UDPConn) ReadFrom(loop *Loop, buf []byte, handler UDPReadHandler) error {
+	if len(buf) == 0 {
+		return ErrEmptyBuffer
+	}
+
 	c.loop = loop
 	c.readHandler = handler
 	c.readBuf = buf
@@ -267,6 +271,10 @@ func (c *UDPConn) readCallback(loop *cxev.Loop, comp *cxev.UDPCompletion, remote
 //
 // The address should be in "host:port" format.
 func (c *UDPConn) WriteTo(loop *Loop, data []byte, address string, handler UDPWriteHandler) error {
+	if len(data) == 0 {
+		return ErrEmptyBuffer
+	}
+
 	c.loop = loop
 	c.writeHandler = handler
 
@@ -297,6 +305,9 @@ func (c *UDPConn) WriteToFunc(loop *Loop, data []byte, address string, fn func(c
 func (c *UDPConn) WriteToAddr(loop *Loop, data []byte, addr *net.UDPAddr, handler UDPWriteHandler) error {
 	if addr == nil {
 		return errors.New("address is nil")
+	}
+	if len(data) == 0 {
+		return ErrEmptyBuffer
 	}
 
 	c.loop = loop


### PR DESCRIPTION
## Summary
This PR hardens async buffer handling by eliminating zero-length slice panics across both `xev` and `cxev` paths.

## Linked Issue
Closes #11

## Scope
- In scope:
  - Add explicit empty-buffer validation in high-level `xev` read/write APIs.
  - Replace direct `&buf[0]` usage in low-level `cxev` FFI wrappers with safe pointer handling.
  - Add regression tests for empty-buffer behavior and callback registration safety.
- Out of scope:
  - Protocol/API redesign beyond empty-buffer guard semantics.

## Definition of Done
- [x] Matches issue acceptance criteria
- [x] Tests added/updated for changed behavior
- [x] No docs drift for changed user-facing behavior

## Verification
- [x] `just check`
- [x] `just test-quick`
- [x] Additional targeted tests:
  - `LIBXEV_PATH=$PWD/deps/libxev/zig-out/lib/libxev.dylib LIBXEV_EXT_PATH=$PWD/zig/zig-out/lib/libxev_extended.dylib go test ./pkg/cxev ./pkg/xev -run EmptyBuffer -count=1 -v`

## Performance and Latency (if applicable)
- Not performance-sensitive by design; changes are guardrails and pointer safety checks only.

## Risk and Rollback
- Risk level: Low
- Rollback plan: Revert this PR commit if any behavior regression appears in integration tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ErrEmptyBuffer` error to prevent operations with empty buffers.

* **Bug Fixes**
  * Improved buffer pointer handling with early validation for empty buffers in TCP, UDP, and File operations, preventing potential unsafe operations.

* **Tests**
  * Added test coverage for empty buffer scenarios across TCP, UDP, and File operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->