### PR TITLE
redisproto: add RESP2 parser and encoder foundation

### DIFF
--- a/pkg/redisproto/encoder.go
+++ b/pkg/redisproto/encoder.go
@@ -1,0 +1,64 @@
+/*
+ * MIT License
+ * Copyright (c) 2026 Crrow
+ */
+
+package redisproto
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Encode serializes a single RESP2 value.
+func Encode(v Value) ([]byte, error) {
+	return AppendEncode(nil, v)
+}
+
+// AppendEncode appends serialized bytes for v into dst.
+func AppendEncode(dst []byte, v Value) ([]byte, error) {
+	if err := v.validateForEncode(); err != nil {
+		return nil, err
+	}
+
+	switch v.Kind {
+	case KindSimpleString:
+		dst = append(dst, '+')
+		dst = append(dst, v.Str...)
+		dst = append(dst, '\r', '\n')
+		return dst, nil
+	case KindError:
+		dst = append(dst, '-')
+		dst = append(dst, v.Str...)
+		dst = append(dst, '\r', '\n')
+		return dst, nil
+	case KindInteger:
+		dst = append(dst, ':')
+		dst = strconv.AppendInt(dst, v.Int, 10)
+		dst = append(dst, '\r', '\n')
+		return dst, nil
+	case KindBulkString:
+		dst = append(dst, '$')
+		dst = strconv.AppendInt(dst, int64(len(v.Bulk)), 10)
+		dst = append(dst, '\r', '\n')
+		dst = append(dst, v.Bulk...)
+		dst = append(dst, '\r', '\n')
+		return dst, nil
+	case KindArray:
+		dst = append(dst, '*')
+		dst = strconv.AppendInt(dst, int64(len(v.Array)), 10)
+		dst = append(dst, '\r', '\n')
+		for _, item := range v.Array {
+			var err error
+			dst, err = AppendEncode(dst, item)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return dst, nil
+	case KindNull:
+		return append(dst, '$', '-', '1', '\r', '\n'), nil
+	default:
+		return nil, fmt.Errorf("unsupported kind: %s", v.Kind)
+	}
+}

--- a/pkg/redisproto/parser.go
+++ b/pkg/redisproto/parser.go
@@ -1,0 +1,178 @@
+/*
+ * MIT License
+ * Copyright (c) 2026 Crrow
+ */
+
+package redisproto
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+const defaultMaxBulkLen = 512 << 20 // 512 MiB
+const defaultMaxArrayLen = 1 << 20  // 1M elements
+const defaultMaxDepth = 64
+
+// Parser incrementally parses RESP2 frames from streaming input.
+type Parser struct {
+	buf         []byte
+	maxBulkLen  int
+	maxArrayLen int
+	maxDepth    int
+}
+
+// NewParser creates a parser with safe default limits.
+func NewParser() *Parser {
+	return &Parser{
+		maxBulkLen:  defaultMaxBulkLen,
+		maxArrayLen: defaultMaxArrayLen,
+		maxDepth:    defaultMaxDepth,
+	}
+}
+
+// Feed appends incoming bytes and returns all fully decoded frames.
+// It keeps incomplete tails in parser state for the next call.
+func (p *Parser) Feed(in []byte) ([]Value, error) {
+	if len(in) > 0 {
+		p.buf = append(p.buf, in...)
+	}
+
+	if len(p.buf) == 0 {
+		return nil, nil
+	}
+
+	out := make([]Value, 0, 1)
+	offset := 0
+
+	for offset < len(p.buf) {
+		v, next, complete, err := p.parseAt(p.buf, offset, 0)
+		if err != nil {
+			p.buf = p.buf[:0]
+			return nil, err
+		}
+		if !complete {
+			break
+		}
+		out = append(out, v)
+		offset = next
+	}
+
+	if offset == len(p.buf) {
+		p.buf = p.buf[:0]
+	} else if offset > 0 {
+		p.buf = append([]byte(nil), p.buf[offset:]...)
+	}
+
+	return out, nil
+}
+
+func (p *Parser) parseAt(data []byte, offset, depth int) (Value, int, bool, error) {
+	if depth > p.maxDepth {
+		return Value{}, 0, false, fmt.Errorf("array nesting exceeds max depth %d", p.maxDepth)
+	}
+	if offset >= len(data) {
+		return Value{}, 0, false, nil
+	}
+
+	prefix := data[offset]
+	offset++
+
+	switch prefix {
+	case '+', '-', ':':
+		line, next, ok := readLine(data, offset)
+		if !ok {
+			return Value{}, 0, false, nil
+		}
+		switch prefix {
+		case '+':
+			return Value{Kind: KindSimpleString, Str: string(line)}, next, true, nil
+		case '-':
+			return Value{Kind: KindError, Str: string(line)}, next, true, nil
+		default:
+			n, err := strconv.ParseInt(string(line), 10, 64)
+			if err != nil {
+				return Value{}, 0, false, fmt.Errorf("invalid integer %q: %w", string(line), err)
+			}
+			return Value{Kind: KindInteger, Int: n}, next, true, nil
+		}
+	case '$':
+		line, next, ok := readLine(data, offset)
+		if !ok {
+			return Value{}, 0, false, nil
+		}
+		n, err := strconv.ParseInt(string(line), 10, 64)
+		if err != nil {
+			return Value{}, 0, false, fmt.Errorf("invalid bulk string length %q: %w", string(line), err)
+		}
+		if n == -1 {
+			return Value{Kind: KindNull}, next, true, nil
+		}
+		if n < -1 {
+			return Value{}, 0, false, fmt.Errorf("negative bulk string length: %d", n)
+		}
+		if n > int64(p.maxBulkLen) {
+			return Value{}, 0, false, fmt.Errorf("bulk string length %d exceeds limit %d", n, p.maxBulkLen)
+		}
+
+		need := next + int(n) + 2
+		if need > len(data) {
+			return Value{}, 0, false, nil
+		}
+		if data[next+int(n)] != '\r' || data[next+int(n)+1] != '\n' {
+			return Value{}, 0, false, fmt.Errorf("bulk string missing CRLF terminator")
+		}
+
+		bulk := append([]byte(nil), data[next:next+int(n)]...)
+		if n == 0 {
+			bulk = []byte{}
+		}
+		return Value{Kind: KindBulkString, Bulk: bulk}, need, true, nil
+	case '*':
+		line, next, ok := readLine(data, offset)
+		if !ok {
+			return Value{}, 0, false, nil
+		}
+
+		n, err := strconv.ParseInt(string(line), 10, 64)
+		if err != nil {
+			return Value{}, 0, false, fmt.Errorf("invalid array length %q: %w", string(line), err)
+		}
+		if n < 0 {
+			return Value{}, 0, false, fmt.Errorf("negative array length: %d", n)
+		}
+		if n > int64(p.maxArrayLen) {
+			return Value{}, 0, false, fmt.Errorf("array length %d exceeds limit %d", n, p.maxArrayLen)
+		}
+
+		arr := make([]Value, 0, int(n))
+		cursor := next
+		for i := int64(0); i < n; i++ {
+			item, itemNext, complete, parseErr := p.parseAt(data, cursor, depth+1)
+			if parseErr != nil {
+				return Value{}, 0, false, parseErr
+			}
+			if !complete {
+				return Value{}, 0, false, nil
+			}
+			arr = append(arr, item)
+			cursor = itemNext
+		}
+		return Value{Kind: KindArray, Array: arr}, cursor, true, nil
+	default:
+		return Value{}, 0, false, fmt.Errorf("unknown RESP2 prefix byte %q", prefix)
+	}
+}
+
+func readLine(data []byte, offset int) ([]byte, int, bool) {
+	if offset >= len(data) {
+		return nil, 0, false
+	}
+	i := bytes.Index(data[offset:], []byte("\r\n"))
+	if i < 0 {
+		return nil, 0, false
+	}
+	end := offset + i
+	return data[offset:end], end + 2, true
+}

--- a/pkg/redisproto/resp2_test.go
+++ b/pkg/redisproto/resp2_test.go
@@ -1,0 +1,208 @@
+/*
+ * MIT License
+ * Copyright (c) 2026 Crrow
+ */
+
+package redisproto
+
+import (
+	"bytes"
+	"math/rand"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParserPartialAndMultiFrame(t *testing.T) {
+	parser := NewParser()
+	chunks := [][]byte{
+		[]byte("+OK\r\n:12"),
+		[]byte("3\r\n$3\r\nfoo\r\n"),
+	}
+
+	var all []Value
+	for i, chunk := range chunks {
+		out, err := parser.Feed(chunk)
+		if err != nil {
+			t.Fatalf("feed %d failed: %v", i, err)
+		}
+		all = append(all, out...)
+	}
+
+	want := []Value{
+		{Kind: KindSimpleString, Str: "OK"},
+		{Kind: KindInteger, Int: 123},
+		{Kind: KindBulkString, Bulk: []byte("foo")},
+	}
+	if !reflect.DeepEqual(all, want) {
+		t.Fatalf("unexpected parsed values: got=%#v want=%#v", all, want)
+	}
+}
+
+func TestParserArrayAndNull(t *testing.T) {
+	parser := NewParser()
+	resp := "*4\r\n$3\r\nGET\r\n$3\r\nkey\r\n$-1\r\n:1\r\n"
+	out, err := parser.Feed([]byte(resp))
+	if err != nil {
+		t.Fatalf("feed failed: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(out))
+	}
+
+	want := Value{Kind: KindArray, Array: []Value{
+		{Kind: KindBulkString, Bulk: []byte("GET")},
+		{Kind: KindBulkString, Bulk: []byte("key")},
+		{Kind: KindNull},
+		{Kind: KindInteger, Int: 1},
+	}}
+	if !reflect.DeepEqual(out[0], want) {
+		t.Fatalf("unexpected frame: got=%#v want=%#v", out[0], want)
+	}
+}
+
+func TestParserMalformedFrames(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		errLike string
+	}{
+		{name: "unknown prefix", input: "!oops\r\n", errLike: "unknown RESP2 prefix"},
+		{name: "bad integer", input: ":1x\r\n", errLike: "invalid integer"},
+		{name: "bad bulk len", input: "$x\r\n", errLike: "invalid bulk string length"},
+		{name: "negative bulk len", input: "$-2\r\n", errLike: "negative bulk string length"},
+		{name: "negative array len", input: "*-2\r\n", errLike: "negative array length"},
+		{name: "broken bulk tail", input: "$3\r\nfooxx", errLike: "bulk string missing CRLF terminator"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewParser()
+			_, err := parser.Feed([]byte(tt.input))
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !contains(err, tt.errLike) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestEncodeTable(t *testing.T) {
+	tests := []struct {
+		name string
+		in   Value
+		out  string
+	}{
+		{name: "simple", in: Value{Kind: KindSimpleString, Str: "OK"}, out: "+OK\r\n"},
+		{name: "error", in: Value{Kind: KindError, Str: "ERR fail"}, out: "-ERR fail\r\n"},
+		{name: "integer", in: Value{Kind: KindInteger, Int: -2}, out: ":-2\r\n"},
+		{name: "bulk", in: Value{Kind: KindBulkString, Bulk: []byte("foo")}, out: "$3\r\nfoo\r\n"},
+		{name: "null", in: Value{Kind: KindNull}, out: "$-1\r\n"},
+		{name: "array", in: Value{Kind: KindArray, Array: []Value{{Kind: KindBulkString, Bulk: []byte("PING")}, {Kind: KindBulkString, Bulk: []byte("x")}}}, out: "*2\r\n$4\r\nPING\r\n$1\r\nx\r\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Encode(tt.in)
+			if err != nil {
+				t.Fatalf("encode failed: %v", err)
+			}
+			if string(got) != tt.out {
+				t.Fatalf("unexpected encoding: got=%q want=%q", string(got), tt.out)
+			}
+		})
+	}
+}
+
+func TestEncodeRejectsInvalidInlineNewline(t *testing.T) {
+	_, err := Encode(Value{Kind: KindSimpleString, Str: "bad\r\nvalue"})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+}
+
+func TestRoundTripRandomized(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	values := make([]Value, 0, 200)
+
+	for i := 0; i < 200; i++ {
+		v := randomValue(rng, 0)
+		if v.Kind == KindSimpleString || v.Kind == KindError {
+			if hasRESPNewline(v.Str) {
+				i--
+				continue
+			}
+		}
+		values = append(values, v)
+	}
+
+	wire := make([]byte, 0, 4096)
+	for _, v := range values {
+		enc, err := Encode(v)
+		if err != nil {
+			t.Fatalf("encode failed: %v", err)
+		}
+		wire = append(wire, enc...)
+	}
+
+	parser := NewParser()
+	got, err := parser.Feed(wire)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if !reflect.DeepEqual(got, values) {
+		t.Fatalf("round-trip mismatch")
+	}
+
+	rest, err := parser.Feed(nil)
+	if err != nil {
+		t.Fatalf("second feed failed: %v", err)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("expected empty on second feed, got %d", len(rest))
+	}
+}
+
+func randomValue(rng *rand.Rand, depth int) Value {
+	if depth >= 2 {
+		return terminalValue(rng)
+	}
+	if rng.Intn(100) < 25 {
+		return terminalValue(rng)
+	}
+
+	n := rng.Intn(4)
+	arr := make([]Value, 0, n)
+	for i := 0; i < n; i++ {
+		arr = append(arr, randomValue(rng, depth+1))
+	}
+	return Value{Kind: KindArray, Array: arr}
+}
+
+func terminalValue(rng *rand.Rand) Value {
+	switch rng.Intn(5) {
+	case 0:
+		return Value{Kind: KindSimpleString, Str: "OK"}
+	case 1:
+		return Value{Kind: KindError, Str: "ERR sample"}
+	case 2:
+		return Value{Kind: KindInteger, Int: int64(rng.Intn(2000) - 1000)}
+	case 3:
+		b := make([]byte, rng.Intn(16))
+		for i := range b {
+			b[i] = byte('a' + rng.Intn(26))
+		}
+		return Value{Kind: KindBulkString, Bulk: b}
+	default:
+		return Value{Kind: KindNull}
+	}
+}
+
+func contains(err error, want string) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), want) || bytes.Contains([]byte(err.Error()), []byte(want))
+}

--- a/pkg/redisproto/types.go
+++ b/pkg/redisproto/types.go
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ * Copyright (c) 2026 Crrow
+ */
+
+package redisproto
+
+import "fmt"
+
+// Kind identifies RESP2 value types supported by MVP.
+type Kind int
+
+const (
+	KindSimpleString Kind = iota
+	KindError
+	KindInteger
+	KindBulkString
+	KindArray
+	KindNull
+)
+
+// Value is a typed RESP2 value.
+type Value struct {
+	Kind  Kind
+	Str   string
+	Int   int64
+	Bulk  []byte
+	Array []Value
+}
+
+func (k Kind) String() string {
+	switch k {
+	case KindSimpleString:
+		return "simple_string"
+	case KindError:
+		return "error"
+	case KindInteger:
+		return "integer"
+	case KindBulkString:
+		return "bulk_string"
+	case KindArray:
+		return "array"
+	case KindNull:
+		return "null"
+	default:
+		return "unknown"
+	}
+}
+
+func (v Value) validateForEncode() error {
+	switch v.Kind {
+	case KindSimpleString, KindError:
+		if hasRESPNewline(v.Str) {
+			return fmt.Errorf("%s contains CR or LF", v.Kind)
+		}
+		return nil
+	case KindInteger, KindBulkString, KindArray, KindNull:
+		return nil
+	default:
+		return fmt.Errorf("unsupported kind: %d", v.Kind)
+	}
+}
+
+func hasRESPNewline(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\r' || s[i] == '\n' {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- add pkg/redisproto with RESP2 MVP value model
- implement streaming parser that supports partial frames and multiple frames per feed
- implement encoder for Simple String, Error, Integer, Bulk String, Array, and Null Bulk String
- add table-driven malformed frame tests and randomized round-trip coverage

Closes #14

## Validation
- go test ./pkg/redisproto -count=1 -v
- just check
- just test-quick
