### PR TITLE
rediscli: add Redis CLI MVP with one-shot and interactive modes

### DIFF
--- a/cmd/redis-cli/main.go
+++ b/cmd/redis-cli/main.go
@@ -1,0 +1,28 @@
+/*
+ * MIT License
+ * Copyright (c) 2026 Crrow
+ */
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/crrow/libxev-go/pkg/rediscli"
+)
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:6379", "redis server address")
+	auth := flag.String("auth", "", "auth token placeholder (not used yet)")
+	flag.Parse()
+
+	if *auth != "" {
+		_, _ = fmt.Fprintln(os.Stderr, "warning: --auth is currently a placeholder and is not applied")
+	}
+
+	client := rediscli.NewClient(*addr)
+	exitCode := client.Run(flag.Args(), os.Stdin, os.Stdout, os.Stderr)
+	os.Exit(exitCode)
+}

--- a/pkg/rediscli/client.go
+++ b/pkg/rediscli/client.go
@@ -1,0 +1,197 @@
+/*
+ * MIT License
+ * Copyright (c) 2026 Crrow
+ */
+
+package rediscli
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/crrow/libxev-go/pkg/redisproto"
+)
+
+// ErrEmptyCommand indicates no command tokens were provided.
+var ErrEmptyCommand = errors.New("empty command")
+
+// Client executes RESP2 commands against a Redis-compatible endpoint.
+type Client struct {
+	Addr    string
+	Timeout time.Duration
+	Dial    func(network, addr string) (net.Conn, error)
+}
+
+// NewClient creates a client with default TCP dial behavior.
+func NewClient(addr string) *Client {
+	return &Client{
+		Addr:    addr,
+		Timeout: 2 * time.Second,
+		Dial: func(network, addr string) (net.Conn, error) {
+			d := net.Dialer{Timeout: 2 * time.Second}
+			return d.Dial(network, addr)
+		},
+	}
+}
+
+// Run executes one-shot or interactive mode depending on args.
+// If args are empty, it enters interactive mode.
+func (c *Client) Run(args []string, in io.Reader, out, errOut io.Writer) int {
+	if len(args) > 0 {
+		if err := c.runOneShot(args, out, errOut); err != nil {
+			_, _ = fmt.Fprintf(errOut, "redis-cli error: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+
+	if err := c.runInteractive(in, out, errOut); err != nil {
+		_, _ = fmt.Fprintf(errOut, "redis-cli error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func (c *Client) runOneShot(args []string, out, errOut io.Writer) error {
+	resp, err := c.Do(args)
+	if err != nil {
+		return err
+	}
+	_, _ = fmt.Fprintln(out, FormatValue(resp))
+	if resp.Kind == redisproto.KindError {
+		_, _ = fmt.Fprintln(errOut, "server returned an error reply")
+	}
+	return nil
+}
+
+func (c *Client) runInteractive(in io.Reader, out, errOut io.Writer) error {
+	_, _ = fmt.Fprintln(out, "redis-cli interactive mode (type 'quit' or 'exit' to leave)")
+	scanner := bufio.NewScanner(in)
+
+	for {
+		_, _ = fmt.Fprint(out, "redis> ")
+		if !scanner.Scan() {
+			if scanErr := scanner.Err(); scanErr != nil {
+				return scanErr
+			}
+			return nil
+		}
+
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.EqualFold(line, "quit") || strings.EqualFold(line, "exit") {
+			return nil
+		}
+
+		args := strings.Fields(line)
+		resp, err := c.Do(args)
+		if err != nil {
+			_, _ = fmt.Fprintf(errOut, "redis-cli error: %v\n", err)
+			continue
+		}
+		_, _ = fmt.Fprintln(out, FormatValue(resp))
+	}
+}
+
+// Do sends a single command and waits for one response frame.
+func (c *Client) Do(args []string) (redisproto.Value, error) {
+	if len(args) == 0 {
+		return redisproto.Value{}, ErrEmptyCommand
+	}
+
+	conn, err := c.Dial("tcp", c.Addr)
+	if err != nil {
+		return redisproto.Value{}, fmt.Errorf("connect %s failed: %w", c.Addr, err)
+	}
+	defer conn.Close()
+	if c.Timeout > 0 {
+		_ = conn.SetDeadline(time.Now().Add(c.Timeout))
+	}
+
+	cmd := BuildCommand(args)
+	wire, err := redisproto.Encode(cmd)
+	if err != nil {
+		return redisproto.Value{}, fmt.Errorf("encode command failed: %w", err)
+	}
+
+	if _, err = conn.Write(wire); err != nil {
+		return redisproto.Value{}, fmt.Errorf("write command failed: %w", err)
+	}
+
+	resp, err := ReadResponse(conn)
+	if err != nil {
+		return redisproto.Value{}, err
+	}
+	return resp, nil
+}
+
+// BuildCommand constructs a RESP2 array of bulk strings.
+func BuildCommand(args []string) redisproto.Value {
+	arr := make([]redisproto.Value, 0, len(args))
+	for _, arg := range args {
+		arr = append(arr, redisproto.Value{Kind: redisproto.KindBulkString, Bulk: []byte(arg)})
+	}
+	return redisproto.Value{Kind: redisproto.KindArray, Array: arr}
+}
+
+// ReadResponse reads one RESP2 frame from reader.
+func ReadResponse(r io.Reader) (redisproto.Value, error) {
+	parser := redisproto.NewParser()
+	br := bufio.NewReader(r)
+	buf := make([]byte, 4096)
+
+	for {
+		n, err := br.Read(buf)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return redisproto.Value{}, fmt.Errorf("protocol error: connection closed before response")
+			}
+			return redisproto.Value{}, fmt.Errorf("read response failed: %w", err)
+		}
+
+		frames, parseErr := parser.Feed(buf[:n])
+		if parseErr != nil {
+			return redisproto.Value{}, fmt.Errorf("protocol error: %w", parseErr)
+		}
+		if len(frames) > 0 {
+			return frames[0], nil
+		}
+	}
+}
+
+// FormatValue renders RESP2 values for CLI output.
+func FormatValue(v redisproto.Value) string {
+	switch v.Kind {
+	case redisproto.KindSimpleString:
+		return v.Str
+	case redisproto.KindError:
+		return "(error) " + v.Str
+	case redisproto.KindInteger:
+		return fmt.Sprintf("(integer) %d", v.Int)
+	case redisproto.KindBulkString:
+		return string(v.Bulk)
+	case redisproto.KindNull:
+		return "(nil)"
+	case redisproto.KindArray:
+		if len(v.Array) == 0 {
+			return "(empty array)"
+		}
+		var b strings.Builder
+		for i, item := range v.Array {
+			_, _ = fmt.Fprintf(&b, "%d) %s", i+1, FormatValue(item))
+			if i < len(v.Array)-1 {
+				_ = b.WriteByte('\n')
+			}
+		}
+		return b.String()
+	default:
+		return "(unknown)"
+	}
+}

--- a/pkg/rediscli/client_test.go
+++ b/pkg/rediscli/client_test.go
@@ -1,0 +1,244 @@
+/*
+ * MIT License
+ * Copyright (c) 2026 Crrow
+ */
+
+package rediscli
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/crrow/libxev-go/pkg/cxev"
+	"github.com/crrow/libxev-go/pkg/redismvp"
+	"github.com/crrow/libxev-go/pkg/redisproto"
+)
+
+func TestRedisCLIBuildCommand(t *testing.T) {
+	got := BuildCommand([]string{"SET", "k", "v"})
+	want := redisproto.Value{Kind: redisproto.KindArray, Array: []redisproto.Value{
+		{Kind: redisproto.KindBulkString, Bulk: []byte("SET")},
+		{Kind: redisproto.KindBulkString, Bulk: []byte("k")},
+		{Kind: redisproto.KindBulkString, Bulk: []byte("v")},
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected command frame: got=%#v want=%#v", got, want)
+	}
+}
+
+func TestRedisCLIReadResponseProtocolError(t *testing.T) {
+	reader := bytes.NewBufferString("!bad\r\n")
+	_, err := ReadResponse(reader)
+	if err == nil {
+		t.Fatalf("expected protocol error")
+	}
+	if !strings.Contains(err.Error(), "protocol error") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRedisCLIRunOneShotAndInteractive(t *testing.T) {
+	client := NewClient("fake")
+	client.Timeout = time.Second
+
+	var (
+		mu        sync.Mutex
+		callIndex int
+	)
+	client.Dial = func(network, addr string) (net.Conn, error) {
+		server, cli := net.Pipe()
+
+		mu.Lock()
+		idx := callIndex
+		callIndex++
+		mu.Unlock()
+
+		go func(call int) {
+			defer server.Close()
+			req := make([]byte, 256)
+			n, _ := server.Read(req)
+			parser := redisproto.NewParser()
+			frames, err := parser.Feed(req[:n])
+			if err != nil || len(frames) == 0 {
+				return
+			}
+
+			var resp redisproto.Value
+			switch call {
+			case 0:
+				resp = redisproto.Value{Kind: redisproto.KindSimpleString, Str: "PONG"}
+			case 1:
+				resp = redisproto.Value{Kind: redisproto.KindSimpleString, Str: "OK"}
+			case 2:
+				resp = redisproto.Value{Kind: redisproto.KindBulkString, Bulk: []byte("v")}
+			default:
+				resp = redisproto.Value{Kind: redisproto.KindError, Str: "ERR value is not an integer or out of range"}
+			}
+			wire, _ := redisproto.Encode(resp)
+			_, _ = server.Write(wire)
+		}(idx)
+
+		return cli, nil
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := client.Run([]string{"PING"}, bytes.NewBuffer(nil), &out, &errOut)
+	if code != 0 {
+		t.Fatalf("expected success exit code, got %d", code)
+	}
+	if strings.TrimSpace(out.String()) != "PONG" {
+		t.Fatalf("unexpected one-shot output: %q", out.String())
+	}
+
+	out.Reset()
+	errOut.Reset()
+	in := bytes.NewBufferString("SET k v\nGET k\nINCR k\nquit\n")
+	code = client.Run(nil, in, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("expected interactive success, got %d, err=%q", code, errOut.String())
+	}
+	stdout := out.String()
+	if !strings.Contains(stdout, "redis-cli interactive mode") {
+		t.Fatalf("missing interactive banner: %q", stdout)
+	}
+	if !strings.Contains(stdout, "OK") || !strings.Contains(stdout, "v") {
+		t.Fatalf("missing command results: %q", stdout)
+	}
+	if !strings.Contains(stdout, "(error) ERR value is not an integer or out of range") {
+		t.Fatalf("missing server error rendering: %q", stdout)
+	}
+}
+
+func TestRedisCLIIntegrationWithRedisServerPing(t *testing.T) {
+	if !cxev.ExtLibLoaded() {
+		t.Skip("extended library not loaded")
+	}
+
+	srv, err := redismvp.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("start server failed: %v", err)
+	}
+	defer func() { _ = srv.Close() }()
+
+	client := NewClient(srv.Addr())
+	client.Timeout = 2 * time.Second
+
+	resp, err := client.Do([]string{"PING"})
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	if resp.Kind != redisproto.KindSimpleString || resp.Str != "PONG" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+}
+
+func TestRedisCLIRunConnectionErrorMessage(t *testing.T) {
+	client := NewClient("127.0.0.1:1")
+	client.Dial = func(network, addr string) (net.Conn, error) {
+		return nil, errors.New("dial failed")
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	code := client.Run([]string{"PING"}, bytes.NewBuffer(nil), &out, &errOut)
+	if code != 1 {
+		t.Fatalf("expected failure exit code, got %d", code)
+	}
+	if !strings.Contains(errOut.String(), "redis-cli error") {
+		t.Fatalf("unexpected stderr: %q", errOut.String())
+	}
+}
+
+func TestRedisCLIDoWithNetPipeRoundTrip(t *testing.T) {
+	server, clientConn := net.Pipe()
+	defer server.Close()
+	defer clientConn.Close()
+
+	client := NewClient("pipe")
+	client.Dial = func(network, addr string) (net.Conn, error) {
+		return clientConn, nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 256)
+		n, _ := server.Read(buf)
+		parser := redisproto.NewParser()
+		frames, err := parser.Feed(buf[:n])
+		if err == nil && len(frames) > 0 {
+			resp, _ := redisproto.Encode(redisproto.Value{Kind: redisproto.KindSimpleString, Str: "PONG"})
+			_, _ = server.Write(resp)
+		}
+	}()
+	resp, err := client.Do([]string{"PING"})
+	if err != nil {
+		t.Fatalf("Do failed: %v", err)
+	}
+	if resp.Kind != redisproto.KindSimpleString || resp.Str != "PONG" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+	<-done
+}
+
+func TestRedisCLITimeoutError(t *testing.T) {
+	client := NewClient("fake")
+	client.Timeout = 100 * time.Millisecond
+	client.Dial = func(network, addr string) (net.Conn, error) {
+		server, cli := net.Pipe()
+		go func() {
+			defer server.Close()
+			_, _ = server.Read(make([]byte, 64))
+			// Intentionally never write response to trigger timeout.
+			time.Sleep(500 * time.Millisecond)
+		}()
+		return cli, nil
+	}
+
+	_, err := client.Do([]string{"PING"})
+	if err == nil {
+		t.Fatalf("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "read response failed") {
+		t.Fatalf("unexpected timeout error: %v", err)
+	}
+}
+
+func TestRedisCLIInteractiveContinuesAfterCommandError(t *testing.T) {
+	client := NewClient("fake")
+	client.Timeout = time.Second
+	client.Dial = func(network, addr string) (net.Conn, error) {
+		server, cli := net.Pipe()
+		go func() {
+			defer server.Close()
+			_, _ = server.Read(make([]byte, 128))
+			resp, _ := redisproto.Encode(redisproto.Value{
+				Kind: redisproto.KindError,
+				Str:  "ERR bad",
+			})
+			_, _ = server.Write(resp)
+		}()
+		return cli, nil
+	}
+
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	in := bytes.NewBufferString("BAD\\nquit\\n")
+	code := client.Run(nil, in, &out, &errOut)
+	if code != 0 {
+		t.Fatalf("expected success exit code, got %d, stderr=%s", code, errOut.String())
+	}
+	if !strings.Contains(out.String(), "(error) ERR bad") {
+		t.Fatalf("expected rendered error reply in stdout: %q", out.String())
+	}
+	if strings.Contains(errOut.String(), "redis-cli error") {
+		t.Fatalf("did not expect network/protocol error in stderr: %q", errOut.String())
+	}
+}


### PR DESCRIPTION
## Summary
- add cmd/redis-cli entrypoint for Redis CLI MVP
- add pkg/rediscli client core with RESP2 command framing and response decoding
- support one-shot command mode and interactive prompt mode
- include auth flag placeholder warning path (`--auth`) without auth logic changes
- add tests for framing, protocol/network failure UX, timeout behavior, interactive mode, and Redis server ping integration

Closes #16

## Validation
- just check
- go test ./... -run 'RedisCLI|CLI' -count=1
- just test-quick


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Redis CLI tool with one-shot and interactive command modes.
  * Configure server address and connection timeout.
  * Real-time formatted output for all Redis response types.
  * Error handling and messaging for failed connections and commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->